### PR TITLE
file name too long

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -239,7 +239,7 @@ apply_development_cox_model_age_sex_adjusted <- function(analysis){
         }
       ),
       moderately_sensitive = list(
-        fit_cox_model = glue("output/not_for_review/model/fit_cox_model_age_sex_adjusted*_{analysis}*"),
+        # fit_cox_model = glue("output/not_for_review/model/cox_as_adj*_{analysis}*"),
         hazard_ratios = glue("output/review/model/HR_age_sex_adjusted_{analysis}*"),
         performance_measure = glue("output/review/model/PM_age_sex_adjusted_{analysis}*")
       )

--- a/analysis/stage3_4_model_dev_eval_age_sex_adjusted.R
+++ b/analysis/stage3_4_model_dev_eval_age_sex_adjusted.R
@@ -64,8 +64,8 @@ for(i in 1:length(cov_names)){
   results$model <- "age_sex_adjusted"
   results$predictor <- cov_factor_names[i]
   combined_results_hr <- rbind(combined_results_hr, results)
-  saveRDS(fit_cox_model, file=paste0("output/not_for_review/model/fit_cox_model_age_sex_adjusted_", cov_names[i],"_", analysis,".rds"))
-  
+  # saveRDS(fit_cox_model, file=paste0("output/not_for_review/model/cox_as_adj_", cov_names[i],"_", analysis,".rds"))
+  # 
   ################################################################################
   ## Part 4: Model evaluation                                                   ##
   ################################################################################

--- a/project.yaml
+++ b/project.yaml
@@ -538,7 +538,6 @@ actions:
     - stage1_define_eligible_population_all
     outputs:
       moderately_sensitive:
-        fit_cox_model: output/not_for_review/model/fit_cox_model_age_sex_adjusted*_all*
         hazard_ratios: output/review/model/HR_age_sex_adjusted_all*
         performance_measure: output/review/model/PM_age_sex_adjusted_all*
 
@@ -550,7 +549,6 @@ actions:
     - stage1_define_eligible_population_all
     outputs:
       moderately_sensitive:
-        fit_cox_model: output/not_for_review/model/fit_cox_model_age_sex_adjusted*_all_vax_c*
         hazard_ratios: output/review/model/HR_age_sex_adjusted_all_vax_c*
         performance_measure: output/review/model/PM_age_sex_adjusted_all_vax_c*
 
@@ -562,7 +560,6 @@ actions:
     - stage1_define_eligible_population_vaccinated
     outputs:
       moderately_sensitive:
-        fit_cox_model: output/not_for_review/model/fit_cox_model_age_sex_adjusted*_vaccinated*
         hazard_ratios: output/review/model/HR_age_sex_adjusted_vaccinated*
         performance_measure: output/review/model/PM_age_sex_adjusted_vaccinated*
 
@@ -574,7 +571,6 @@ actions:
     - stage1_define_eligible_population_all
     outputs:
       moderately_sensitive:
-        fit_cox_model: output/not_for_review/model/fit_cox_model_age_sex_adjusted*_all_vax_td*
         hazard_ratios: output/review/model/HR_age_sex_adjusted_all_vax_td*
         performance_measure: output/review/model/PM_age_sex_adjusted_all_vax_td*
 
@@ -586,7 +582,6 @@ actions:
     - stage1_define_eligible_population_infected
     outputs:
       moderately_sensitive:
-        fit_cox_model: output/not_for_review/model/fit_cox_model_age_sex_adjusted*_infected*
         hazard_ratios: output/review/model/HR_age_sex_adjusted_infected*
         performance_measure: output/review/model/PM_age_sex_adjusted_infected*
 


### PR DESCRIPTION
Updates:

Commented out 
# saveRDS(fit_cox_model, file=paste0("output/not_for_review/model/cox_as_adj_", cov_names[i],"_", analysis,".rds"))
in stage3_4_dev_eval_age_sex_adjusted.R

because 
1) despite it works on real data and on github, the code failed to run locally because file name is too long for some variables (such as the full spelling of COPD) - worth to review naming principles and use short variable names (in study definition or change in stage 0)
2) this raw output file is not needed as it duplicates the extracted results which are stored in an excel spreadsheet